### PR TITLE
fix: replace deprecated actions/create-release with gh CLI for creati…

### DIFF
--- a/.github/workflows/auth-service.yml
+++ b/.github/workflows/auth-service.yml
@@ -70,21 +70,17 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          release_name: Auth Service Release ${{ steps.version.outputs.version }}
-          body: |
-            Auth Service Release ${{ steps.version.outputs.version }}
+        run: |
+          gh release create ${{ steps.version.outputs.version }} \
+            --title "Auth Service Release ${{ steps.version.outputs.version }}" \
+            --notes "Auth Service Release ${{ steps.version.outputs.version }}
             
-            Docker image: `${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}`
+            Docker image: \`${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}\`
             
             ## What's Changed
-            See commit history for changes included in this release.
-          draft: false
-          prerelease: false
+            See commit history for changes included in this release."
 
   build-and-push:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/content-service.yml
+++ b/.github/workflows/content-service.yml
@@ -68,21 +68,17 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          release_name: Content Service Release ${{ steps.version.outputs.version }}
-          body: |
-            Content Service Release ${{ steps.version.outputs.version }}
+        run: |
+          gh release create ${{ steps.version.outputs.version }} \
+            --title "Content Service Release ${{ steps.version.outputs.version }}" \
+            --notes "Content Service Release ${{ steps.version.outputs.version }}
             
-            Docker image: `${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}`
+            Docker image: \`${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}\`
             
             ## What's Changed
-            See commit history for changes included in this release.
-          draft: false
-          prerelease: false
+            See commit history for changes included in this release."
 
   build-and-push:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -72,21 +72,17 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          release_name: Frontend Release ${{ steps.version.outputs.version }}
-          body: |
-            Frontend Service Release ${{ steps.version.outputs.version }}
+        run: |
+          gh release create ${{ steps.version.outputs.version }} \
+            --title "Frontend Release ${{ steps.version.outputs.version }}" \
+            --notes "Frontend Service Release ${{ steps.version.outputs.version }}
             
-            Docker image: `${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}`
+            Docker image: \`${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}\`
             
             ## What's Changed
-            See commit history for changes included in this release.
-          draft: false
-          prerelease: false
+            See commit history for changes included in this release."
 
   build-and-push:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/user-service.yml
+++ b/.github/workflows/user-service.yml
@@ -70,21 +70,17 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          release_name: User Service Release ${{ steps.version.outputs.version }}
-          body: |
-            User Service Release ${{ steps.version.outputs.version }}
+        run: |
+          gh release create ${{ steps.version.outputs.version }} \
+            --title "User Service Release ${{ steps.version.outputs.version }}" \
+            --notes "User Service Release ${{ steps.version.outputs.version }}
             
-            Docker image: `${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}`
+            Docker image: \`${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}\`
             
             ## What's Changed
-            See commit history for changes included in this release.
-          draft: false
-          prerelease: false
+            See commit history for changes included in this release."
 
   build-and-push:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
…ng releases

- Fix 'Resource not accessible by integration' error
- Use gh release create command which works with default GITHUB_TOKEN permissions
- Maintain same release format and information