### PR TITLE
fix: add permissions block and revert to actions/create-release@v1

### DIFF
--- a/.github/workflows/auth-service.yml
+++ b/.github/workflows/auth-service.yml
@@ -12,6 +12,9 @@ on:
       - 'services/auth-service/**'
       - '.github/workflows/auth-service.yml'
 
+permissions:
+  contents: write
+
 env:
   SERVICE_NAME: auth-service
   SERVICE_PATH: ./services/auth-service
@@ -70,17 +73,21 @@ jobs:
 
       - name: Create Release
         id: create_release
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create ${{ steps.version.outputs.version }} \
-            --title "Auth Service Release ${{ steps.version.outputs.version }}" \
-            --notes "Auth Service Release ${{ steps.version.outputs.version }}
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          release_name: Auth Service Release ${{ steps.version.outputs.version }}
+          body: |
+            Auth Service Release ${{ steps.version.outputs.version }}
             
-            Docker image: \`${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}\`
+            Docker image: `${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}`
             
             ## What's Changed
-            See commit history for changes included in this release."
+            See commit history for changes included in this release.
+          draft: false
+          prerelease: false
 
   build-and-push:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/content-service.yml
+++ b/.github/workflows/content-service.yml
@@ -12,6 +12,9 @@ on:
       - 'services/content-service/**'
       - '.github/workflows/content-service.yml'
 
+permissions:
+  contents: write
+
 env:
   SERVICE_NAME: content-service
   SERVICE_PATH: ./services/content-service
@@ -68,17 +71,21 @@ jobs:
 
       - name: Create Release
         id: create_release
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create ${{ steps.version.outputs.version }} \
-            --title "Content Service Release ${{ steps.version.outputs.version }}" \
-            --notes "Content Service Release ${{ steps.version.outputs.version }}
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          release_name: Content Service Release ${{ steps.version.outputs.version }}
+          body: |
+            Content Service Release ${{ steps.version.outputs.version }}
             
-            Docker image: \`${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}\`
+            Docker image: `${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}`
             
             ## What's Changed
-            See commit history for changes included in this release."
+            See commit history for changes included in this release.
+          draft: false
+          prerelease: false
 
   build-and-push:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -12,6 +12,9 @@ on:
       - 'frontend/**'
       - '.github/workflows/frontend.yml'
 
+permissions:
+  contents: write
+
 env:
   SERVICE_NAME: frontend
   SERVICE_PATH: ./frontend
@@ -72,17 +75,21 @@ jobs:
 
       - name: Create Release
         id: create_release
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create ${{ steps.version.outputs.version }} \
-            --title "Frontend Release ${{ steps.version.outputs.version }}" \
-            --notes "Frontend Service Release ${{ steps.version.outputs.version }}
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          release_name: Frontend Release ${{ steps.version.outputs.version }}
+          body: |
+            Frontend Service Release ${{ steps.version.outputs.version }}
             
-            Docker image: \`${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}\`
+            Docker image: `${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}`
             
             ## What's Changed
-            See commit history for changes included in this release."
+            See commit history for changes included in this release.
+          draft: false
+          prerelease: false
 
   build-and-push:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/user-service.yml
+++ b/.github/workflows/user-service.yml
@@ -12,6 +12,9 @@ on:
       - 'services/user-service/**'
       - '.github/workflows/user-service.yml'
 
+permissions:
+  contents: write
+
 env:
   SERVICE_NAME: user-service
   SERVICE_PATH: ./services/user-service
@@ -70,17 +73,21 @@ jobs:
 
       - name: Create Release
         id: create_release
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create ${{ steps.version.outputs.version }} \
-            --title "User Service Release ${{ steps.version.outputs.version }}" \
-            --notes "User Service Release ${{ steps.version.outputs.version }}
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          release_name: User Service Release ${{ steps.version.outputs.version }}
+          body: |
+            User Service Release ${{ steps.version.outputs.version }}
             
-            Docker image: \`${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}\`
+            Docker image: `${{ secrets.DOCKER_USERNAME || 'stevenjiangnz' }}/${{ env.IMAGE_NAME }}:${{ steps.versioning.outputs.new-version }}`
             
             ## What's Changed
-            See commit history for changes included in this release."
+            See commit history for changes included in this release.
+          draft: false
+          prerelease: false
 
   build-and-push:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
- Add 'permissions: contents: write' to all workflows
- This gives GITHUB_TOKEN the necessary permissions to create releases
- Revert back to actions/create-release@v1 as it works with proper permissions
- Based on GitHub Actions documentation for resolving 'Resource not accessible by integration' error