### PR TITLE
fix: update email allowlist middleware to exclude auth paths from checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,8 +245,14 @@ query: "SELECT * FROM public.allowed_users WHERE email = 'user@company.com';"
 mcp__supabase__execute_sql
 query: "SELECT COUNT(*) as total_users FROM public.allowed_users;"
 
-# Note: Users not in the allowlist will be redirected to /unauthorized
-# The middleware checks allowlist on every request for authenticated users
+# Implementation Details:
+# - Table: public.allowed_users (email, created_at, updated_at, added_by)
+# - RLS policies allow anon users to read (required for middleware checks)
+# - Middleware checks allowlist on every request for authenticated users
+# - Users not in allowlist are redirected to /unauthorized
+# - Excluded paths: /login, /auth/*, /unauthorized, / (root)
+# - TypeScript types defined in frontend/src/types/auth.ts
+# - Unauthorized page supports Suspense for Next.js 15 compatibility
 ```
 
 ### Testing

--- a/frontend/src/utils/supabase/middleware.ts
+++ b/frontend/src/utils/supabase/middleware.ts
@@ -48,7 +48,10 @@ export async function updateSession(request: NextRequest) {
 
   // Skip allowlist check for certain paths
   const pathname = request.nextUrl.pathname
-  if (pathname === '/unauthorized' || pathname.startsWith('/auth/')) {
+  if (pathname === '/unauthorized' || 
+      pathname.startsWith('/auth/') || 
+      pathname === '/login' ||
+      pathname === '/') {
     return supabaseResponse
   }
 

--- a/migrations/001_create_allowed_users.sql
+++ b/migrations/001_create_allowed_users.sql
@@ -1,0 +1,40 @@
+-- Migration: Create allowed_users table for email-based access control
+-- Date: 2025-09-10
+-- Description: This table stores the list of email addresses that are allowed to access the application
+
+CREATE TABLE IF NOT EXISTS public.allowed_users (
+  email TEXT PRIMARY KEY,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  added_by TEXT DEFAULT 'system'
+);
+
+-- Create updated_at trigger
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_allowed_users_updated_at BEFORE UPDATE
+  ON allowed_users FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Enable RLS
+ALTER TABLE public.allowed_users ENABLE ROW LEVEL SECURITY;
+
+-- Create policy for service role access
+CREATE POLICY "Service role can manage allowed_users" ON public.allowed_users
+  FOR ALL USING (auth.jwt()->>'role' = 'service_role');
+
+-- IMPORTANT: Create policy for anon users to read the allowlist
+-- This is required for the middleware to check if users are allowed
+CREATE POLICY "Anon users can read allowed_users" ON public.allowed_users
+  FOR SELECT USING (true);
+
+-- Add initial admin users (replace with actual admin emails)
+INSERT INTO public.allowed_users (email) VALUES 
+  ('stevenjiangnz@gmail.com'),
+  ('stevenjiangchat@gmail.com')
+ON CONFLICT (email) DO NOTHING;


### PR DESCRIPTION
- Fixed signout redirect issue by excluding /login, /auth/*, /unauthorized, and / paths from allowlist checks
- Updated CLAUDE.md with implementation details for email allowlist management
- Added migration file documenting the allowed_users table structure and RLS policies
- This ensures users are redirected to login page after signout instead of unauthorized page

🤖 Generated with [Claude Code](https://claude.ai/code)