### PR TITLE
feat(frontend): implement responsive 3-column layout with trading theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,14 +206,16 @@ Deploy to Google Cloud Run:
 
 ## 📝 Features
 
-- [ ] Landing page with portfolio showcase
+- [x] Landing page with 3-column layout (17.5%-65%-17.5% responsive grid)
+- [x] Full-width navigation bar with centered menu items
+- [x] Trading-themed logo and branding
 - [ ] Blog section with markdown support
 - [ ] Contact form with email integration
 - [x] User authentication (Supabase - Email/Password and Google OAuth)
 - [ ] Admin panel for content management
 - [x] Stock/ETF EOD data downloading service
 - [x] Dark/Light mode theme toggle with system preference support
-- [ ] Mobile-responsive design
+- [x] Mobile-responsive design with hamburger menu
 - [ ] SEO optimized
 - [ ] Fast loading (< 3s)
 - [ ] Accessible (WCAG 2.1 AA)

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -101,3 +101,50 @@ body {
 .main-subtitle {
   color: var(--muted-foreground);
 }
+
+/* Sidebar styles */
+.sidebar-card {
+  background-color: var(--card);
+  border: 1px solid var(--border);
+}
+
+.sidebar-link {
+  color: var(--muted-foreground);
+  transition: all 0.2s;
+}
+
+.sidebar-link:hover {
+  color: var(--foreground);
+}
+
+.sidebar-text {
+  color: var(--muted-foreground);
+}
+
+/* Main content styles */
+.main-content-card {
+  background-color: var(--card);
+  border: 1px solid var(--border);
+}
+
+/* Stat card styles */
+.stat-card {
+  background-color: var(--muted);
+  border: 1px solid var(--border);
+}
+
+.stat-label {
+  color: var(--muted-foreground);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.stat-value {
+  color: var(--foreground);
+}
+
+/* Activity item styles */
+.activity-item {
+  background-color: var(--muted);
+  border: 1px solid var(--border);
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -19,24 +19,158 @@ export default async function Home() {
     <div className="main-container">
       <Navbar user={user} />
 
-      <div className="flex items-center justify-center min-h-[calc(100vh-4rem)]">
-        <div className="text-center">
-          <h1 className="text-4xl font-bold main-title">
-            Welcome to JNet Solution
-          </h1>
-          <p className="mt-4 text-lg main-subtitle">
-            {user ? 'You are logged in!' : 'Please sign in to continue'}
-          </p>
-          {!user && (
-            <div className="mt-6">
-              <Link
-                href="/login"
-                className="bg-indigo-600 text-white px-6 py-3 rounded-md hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 transition-colors"
-              >
-                Get Started
-              </Link>
+      <div className="w-full px-4 py-8">
+        <div className="grid grid-cols-1 lg:grid-cols-[175fr_650fr_175fr] gap-4">
+          {/* Left sidebar - 17.5% */}
+          <aside className="hidden lg:block space-y-4">
+            <div className="sidebar-card rounded-lg p-3">
+              <h2 className="text-base font-semibold main-title mb-2">Quick Links</h2>
+              <nav className="space-y-1">
+                <a href="#" className="block sidebar-link p-1.5 text-sm rounded hover:bg-gray-100 dark:hover:bg-gray-800">
+                  Portfolio Overview
+                </a>
+                <a href="#" className="block sidebar-link p-1.5 text-sm rounded hover:bg-gray-100 dark:hover:bg-gray-800">
+                  Watchlist
+                </a>
+                <a href="#" className="block sidebar-link p-1.5 text-sm rounded hover:bg-gray-100 dark:hover:bg-gray-800">
+                  Recent Trades
+                </a>
+                <a href="#" className="block sidebar-link p-1.5 text-sm rounded hover:bg-gray-100 dark:hover:bg-gray-800">
+                  Market News
+                </a>
+              </nav>
             </div>
-          )}
+            
+            <div className="sidebar-card rounded-lg p-3">
+              <h2 className="text-base font-semibold main-title mb-2">Market Status</h2>
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="sidebar-text">US Market</span>
+                  <span className="text-green-600 dark:text-green-400">Open</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="sidebar-text">ASX</span>
+                  <span className="text-red-600 dark:text-red-400">Closed</span>
+                </div>
+              </div>
+            </div>
+          </aside>
+
+          {/* Main content - 65% */}
+          <main className="w-full">
+            <div className="main-content-card rounded-lg p-8">
+              <h1 className="text-4xl font-bold main-title">
+                Welcome to JNet Solution
+              </h1>
+              <p className="mt-4 text-lg main-subtitle">
+                {user ? 'Your Trading Dashboard' : 'Please sign in to continue'}
+              </p>
+              
+              {user ? (
+                <div className="mt-8 space-y-6">
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="stat-card rounded-lg p-4">
+                      <h3 className="text-sm stat-label">Total Portfolio Value</h3>
+                      <p className="text-2xl font-bold stat-value">$125,430.50</p>
+                      <p className="text-sm text-green-600 dark:text-green-400">+2.3% today</p>
+                    </div>
+                    <div className="stat-card rounded-lg p-4">
+                      <h3 className="text-sm stat-label">Daily P&L</h3>
+                      <p className="text-2xl font-bold stat-value">+$2,854.32</p>
+                      <p className="text-sm text-green-600 dark:text-green-400">+15.2% vs yesterday</p>
+                    </div>
+                  </div>
+                  
+                  <div className="main-content-card rounded-lg p-6">
+                    <h2 className="text-xl font-semibold main-title mb-4">Recent Activity</h2>
+                    <div className="space-y-3">
+                      <div className="activity-item p-3 rounded">
+                        <div className="flex justify-between items-center">
+                          <div>
+                            <p className="font-medium">AAPL Buy Order</p>
+                            <p className="text-sm main-subtitle">100 shares @ $178.25</p>
+                          </div>
+                          <span className="text-sm text-green-600 dark:text-green-400">Filled</span>
+                        </div>
+                      </div>
+                      <div className="activity-item p-3 rounded">
+                        <div className="flex justify-between items-center">
+                          <div>
+                            <p className="font-medium">TSLA Sell Order</p>
+                            <p className="text-sm main-subtitle">50 shares @ $242.80</p>
+                          </div>
+                          <span className="text-sm text-green-600 dark:text-green-400">Filled</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="mt-6">
+                  <Link
+                    href="/login"
+                    className="inline-block bg-indigo-600 text-white px-6 py-3 rounded-md hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 transition-colors"
+                  >
+                    Get Started
+                  </Link>
+                </div>
+              )}
+            </div>
+          </main>
+
+          {/* Right sidebar - 17.5% */}
+          <aside className="hidden xl:block space-y-4">
+            <div className="sidebar-card rounded-lg p-3">
+              <h2 className="text-base font-semibold main-title mb-2">Indices</h2>
+              <div className="space-y-2">
+                <div>
+                  <div className="flex justify-between items-center text-sm">
+                    <span className="font-medium">S&P</span>
+                    <span className="text-green-600 dark:text-green-400 text-xs">+0.8%</span>
+                  </div>
+                  <p className="text-xs sidebar-text">4,783.45</p>
+                </div>
+                <div>
+                  <div className="flex justify-between items-center text-sm">
+                    <span className="font-medium">NAS</span>
+                    <span className="text-green-600 dark:text-green-400 text-xs">+1.2%</span>
+                  </div>
+                  <p className="text-xs sidebar-text">15,245</p>
+                </div>
+                <div>
+                  <div className="flex justify-between items-center text-sm">
+                    <span className="font-medium">DOW</span>
+                    <span className="text-red-600 dark:text-red-400 text-xs">-0.3%</span>
+                  </div>
+                  <p className="text-xs sidebar-text">38,150</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="sidebar-card rounded-lg p-3">
+              <h2 className="text-base font-semibold main-title mb-2">Movers</h2>
+              <div className="space-y-1">
+                <div className="text-sm">
+                  <div className="flex justify-between">
+                    <span className="font-medium text-xs">NVDA</span>
+                    <span className="text-green-600 dark:text-green-400 text-xs">+5.2%</span>
+                  </div>
+                </div>
+                <div className="text-sm">
+                  <div className="flex justify-between">
+                    <span className="font-medium text-xs">META</span>
+                    <span className="text-green-600 dark:text-green-400 text-xs">+3.8%</span>
+                  </div>
+                </div>
+                <div className="text-sm">
+                  <div className="flex justify-between">
+                    <span className="font-medium text-xs">GOOGL</span>
+                    <span className="text-red-600 dark:text-red-400 text-xs">-2.1%</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </aside>
         </div>
       </div>
     </div>

--- a/frontend/src/components/logo.tsx
+++ b/frontend/src/components/logo.tsx
@@ -1,0 +1,34 @@
+export function Logo({ className = "w-8 h-8" }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      {/* Chart bars representing trading */}
+      <rect x="4" y="20" width="4" height="8" fill="currentColor" opacity="0.8" />
+      <rect x="10" y="16" width="4" height="12" fill="currentColor" opacity="0.8" />
+      <rect x="16" y="12" width="4" height="16" fill="currentColor" />
+      <rect x="22" y="8" width="4" height="20" fill="currentColor" opacity="0.8" />
+      
+      {/* Trend line */}
+      <path
+        d="M6 22L12 18L18 14L24 10"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      
+      {/* Arrow indicating growth */}
+      <path
+        d="M24 10L28 6M28 6L24 6M28 6V10"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/mobile-menu.tsx
+++ b/frontend/src/components/mobile-menu.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface MobileMenuProps {
+  user: { email?: string } | null;
+}
+
+export function MobileMenu({ user }: MobileMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+
+  const menuItems = [
+    { href: "/market", label: "Market" },
+    { href: "/screen", label: "Screen" },
+    { href: "/analysis", label: "Analysis" },
+    { href: "/settings", label: "Settings" },
+  ];
+
+  return (
+    <div className="md:hidden">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="p-2 rounded-md navbar-link"
+        aria-label="Toggle menu"
+      >
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          {isOpen ? (
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          ) : (
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 6h16M4 12h16M4 18h16"
+            />
+          )}
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-16 left-0 right-0 bg-white dark:bg-gray-900 shadow-lg z-50">
+          <nav className="px-4 py-2">
+            {menuItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={() => setIsOpen(false)}
+                className={`block py-2 px-3 rounded ${
+                  pathname === item.href
+                    ? "text-indigo-600 dark:text-indigo-400 bg-gray-100 dark:bg-gray-800"
+                    : "navbar-link hover:bg-gray-100 dark:hover:bg-gray-800"
+                }`}
+              >
+                {item.label}
+              </Link>
+            ))}
+            {user && (
+              <>
+                <Link
+                  href="/dashboard"
+                  onClick={() => setIsOpen(false)}
+                  className="block py-2 px-3 rounded navbar-link hover:bg-gray-100 dark:hover:bg-gray-800"
+                >
+                  Dashboard
+                </Link>
+                <div className="border-t border-gray-200 dark:border-gray-700 my-2"></div>
+                <div className="px-3 py-2 text-sm navbar-text">{user.email}</div>
+              </>
+            )}
+          </nav>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -1,54 +1,90 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { ThemeToggle } from "./theme-toggle";
+import { Logo } from "./logo";
+import { MobileMenu } from "./mobile-menu";
 
 interface NavbarProps {
   user: { email?: string } | null;
 }
 
 export function Navbar({ user }: NavbarProps) {
+  const pathname = usePathname();
+  
+  const menuItems = [
+    { href: "/market", label: "Market" },
+    { href: "/screen", label: "Screen" },
+    { href: "/analysis", label: "Analysis" },
+    { href: "/settings", label: "Settings" },
+  ];
+
   return (
     <nav className="navbar shadow-sm">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between h-16">
-          <div className="flex items-center">
+      <div className="w-full px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          {/* Logo and title */}
+          <div className="flex items-center space-x-3">
+            <Logo className="w-8 h-8 text-indigo-600 dark:text-indigo-400" />
             <h1 className="text-xl font-semibold navbar-title">
               JNet Solution
             </h1>
           </div>
+
+          {/* Center menu items */}
+          <div className="hidden md:flex items-center space-x-8">
+            {menuItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`text-sm font-medium transition-colors ${
+                  pathname === item.href
+                    ? "text-indigo-600 dark:text-indigo-400"
+                    : "navbar-link hover:text-indigo-600 dark:hover:text-indigo-400"
+                }`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+
+          {/* Right side items */}
           <div className="flex items-center space-x-4">
             <ThemeToggle />
-            {user ? (
-              <>
-                <span className="text-sm navbar-text">
-                  Hello, {user.email}
-                </span>
-                <Link
-                  href="/dashboard"
-                  className="text-sm navbar-link"
-                >
-                  Dashboard
-                </Link>
-                <form action="/auth/signout" method="post">
-                  <button
-                    type="submit"
+            <MobileMenu user={user} />
+            <div className="hidden md:flex items-center space-x-4">
+              {user ? (
+                <>
+                  <span className="text-sm navbar-text">
+                    {user.email}
+                  </span>
+                  <Link
+                    href="/dashboard"
                     className="text-sm navbar-link"
                   >
-                    Sign Out
-                  </button>
-                </form>
-              </>
-            ) : (
-              <>
-                <Link
-                  href="/login"
-                  className="text-sm navbar-link"
-                >
-                  Sign In
-                </Link>
-              </>
-            )}
+                    Dashboard
+                  </Link>
+                  <form action="/auth/signout" method="post">
+                    <button
+                      type="submit"
+                      className="text-sm navbar-link"
+                    >
+                      Sign Out
+                    </button>
+                  </form>
+                </>
+              ) : (
+                <>
+                  <Link
+                    href="/login"
+                    className="text-sm navbar-link"
+                  >
+                    Sign In
+                  </Link>
+                </>
+              )}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Add full-width navbar with centered menu items (Market, Screen, Analysis, Settings)
- Create trading-themed logo component with chart bars and growth arrow
- Implement responsive 3-column layout (17.5%-65%-17.5% grid)
- Add mobile hamburger menu for smaller screens
- Update main page with trading dashboard mockup content
- Remove max-width constraint to use full screen width
- Update documentation to reflect new UI features

🤖 Generated with [Claude Code](https://claude.ai/code)