### PR TITLE
fix: update frontend workflow for self-hosted runner

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -26,12 +26,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
+      - name: Check Node.js version
+        run: |
+          echo "Using Node.js version:"
+          node --version
+          echo "Using npm version:"
+          npm --version
+
+      - name: Clean workspace
+        working-directory: ${{ env.SERVICE_PATH }}
+        run: |
+          rm -rf node_modules .next
+          npm cache clean --force
 
       - name: Install dependencies
         working-directory: ${{ env.SERVICE_PATH }}


### PR DESCRIPTION
- Remove setup-node action, use pre-installed Node.js v20
- Add workspace cleaning step to avoid stale dependencies
- Clear npm cache to prevent build issues