### PR TITLE
fix: Improve Quick Links hover readability on home page

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -117,6 +117,16 @@ body {
   color: var(--foreground);
 }
 
+.quick-link-item {
+  color: var(--muted-foreground);
+  transition: all 0.2s;
+}
+
+.quick-link-item:hover {
+  background-color: var(--muted);
+  color: var(--foreground);
+}
+
 .sidebar-text {
   color: var(--muted-foreground);
 }

--- a/frontend/src/components/home/home-content.tsx
+++ b/frontend/src/components/home/home-content.tsx
@@ -14,16 +14,16 @@ export function HomeContent() {
           <div className="sidebar-card rounded-lg p-3">
             <h2 className="text-lg font-semibold main-title mb-3">Quick Links</h2>
             <nav className="space-y-1">
-              <a href="#" className="block sidebar-link p-2 text-base rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+              <a href="#" className="block quick-link-item p-2 text-base rounded transition-all">
                 Portfolio Overview
               </a>
-              <a href="#" className="block sidebar-link p-2 text-base rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+              <a href="#" className="block quick-link-item p-2 text-base rounded transition-all">
                 Watchlist
               </a>
-              <a href="#" className="block sidebar-link p-2 text-base rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+              <a href="#" className="block quick-link-item p-2 text-base rounded transition-all">
                 Recent Trades
               </a>
-              <a href="#" className="block sidebar-link p-2 text-base rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+              <a href="#" className="block quick-link-item p-2 text-base rounded transition-all">
                 Market News
               </a>
             </nav>


### PR DESCRIPTION
- Replace sidebar-link class with quick-link-item for better contrast
- Use consistent hover styling matching symbols page design
- Ensure proper text/background contrast in both light and dark modes