### PR TITLE
refactor: Rename Price menu to Market

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Renamed "Price" menu item to "Market" in frontend navigation
+  - Updated navbar and mobile menu components
+  - Renamed `/price` route to `/market`
+  - Updated all related page components and imports
+
 ### Fixed
 - **Supabase Row Level Security (RLS) limitation preventing system config updates**
   - API service now properly uses service role key instead of anon key
@@ -77,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Main content areas now use `bg-black` in dark mode
   - UI elements use deeper grays (`gray-950`, `gray-900`)
   - Improved readability and reduced brightness in dark mode
-- Updated both Symbol Management and Price pages with consistent dark mode styling
+- Updated both Symbol Management and Market pages with consistent dark mode styling
 - **Replaced "Add Symbol" sidebar menu item with prominent button above symbol list**
 - Symbol addition now automatically downloads all historical data (period=max)
 
@@ -94,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2025-09-15
 
 ### Added
-- Price page with 3-column layout for stock charts
+- Market page with 3-column layout for stock charts
   - Left panel: Symbol selector and chart configuration
   - Middle panel: Chart area (placeholder for Highcharts)
   - Right panel: Real-time data point details

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Deploy to Google Cloud Run:
 - [x] Landing page with 3-column layout (17.5%-65%-17.5% responsive grid)
 - [x] Full-width navigation bar with centered menu items
 - [x] Trading-themed logo and branding
-- [x] Price page with 3-column layout for stock charts and data
+- [x] Market page with 3-column layout for stock charts and data
   - Symbol selector with dropdown
   - Chart configuration (timeframe, chart type, indicators)
   - Placeholder for Highcharts stock charts
@@ -286,7 +286,7 @@ Deploy to Google Cloud Run:
 - [x] Dark/Light mode theme toggle with system preference support
   - Enhanced dark mode with deeper blacks and better contrast
 - [x] Mobile-responsive design with hamburger menu
-- [x] Protected routes (authentication required for Price and Symbols pages)
+- [x] Protected routes (authentication required for Market and Symbols pages)
 - [ ] SEO optimized
 - [ ] Fast loading (< 3s)
 - [ ] Accessible (WCAG 2.1 AA)

--- a/frontend/src/app/market/market-content.tsx
+++ b/frontend/src/app/market/market-content.tsx
@@ -25,7 +25,7 @@ const dummyDataPoint = {
   changePercent: 0.78,
 };
 
-export default function PricePageContent() {
+export default function MarketPageContent() {
   const [selectedSymbol, setSelectedSymbol] = useState("AAPL");
   const [timeframe, setTimeframe] = useState("1D");
   const [chartType, setChartType] = useState("candlestick");

--- a/frontend/src/app/market/page.tsx
+++ b/frontend/src/app/market/page.tsx
@@ -1,9 +1,9 @@
 import { redirect } from 'next/navigation'
 import { createClient } from '@/utils/supabase/server'
 import { AppLayout } from '@/components/layout/app-layout'
-import PricePageContent from './price-content'
+import MarketPageContent from './market-content'
 
-export default async function PricePage() {
+export default async function MarketPage() {
   const supabase = await createClient()
   
   let user = null
@@ -20,7 +20,7 @@ export default async function PricePage() {
 
   return (
     <AppLayout>
-      <PricePageContent />
+      <MarketPageContent />
     </AppLayout>
   );
 }

--- a/frontend/src/components/mobile-menu.tsx
+++ b/frontend/src/components/mobile-menu.tsx
@@ -13,7 +13,7 @@ export function MobileMenu({ user }: MobileMenuProps) {
   const pathname = usePathname();
 
   const menuItems = [
-    { href: "/price", label: "Price" },
+    { href: "/market", label: "Market" },
     { href: "/symbols", label: "Symbols" },
     { href: "/screen", label: "Screen" },
     { href: "/analysis", label: "Analysis" },

--- a/frontend/src/components/navbar.tsx
+++ b/frontend/src/components/navbar.tsx
@@ -14,7 +14,7 @@ export function Navbar({ user }: NavbarProps) {
   const pathname = usePathname();
   
   const menuItems = [
-    { href: "/price", label: "Price" },
+    { href: "/market", label: "Market" },
     { href: "/symbols", label: "Symbols" },
     { href: "/screen", label: "Screen" },
     { href: "/analysis", label: "Analysis" },


### PR DESCRIPTION
- Updated navbar and mobile menu components to show 'Market' instead of 'Price'
- Renamed /price route to /market
- Renamed price-content.tsx to market-content.tsx
- Updated all component names from PricePageContent to MarketPageContent
- Updated documentation in README.md and CHANGELOG.md